### PR TITLE
Add correct defaults for oppositeLength props to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ Displays a complete clock.
 |----|----|----|
 |className|Defines class name(s) that will be added along with "react-clock" to the main React-Clock `<time>` element.|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|
 |hourHandLength|Defines the length of an hour hand, in %. Defaults to `50`.|`80`|
-|hourHandOppositeLength|Defines the length of the part of an hour hand on the opposite side the hand is pointing to, in %.|`20`|
+|hourHandOppositeLength|Defines the length of the part of an hour hand on the opposite side the hand is pointing to, in %. Defaults to `10`.|`20`|
 |hourHandWidth|Defines the width of an hour hand, in pixels. Defaults to `4`.|`3`|
 |hourMarksLength|Defines the length of hour marks, in %. Defaults to `10`.|`8`|
 |hourMarksWidth|Defines the width of hour marks, in pixels. Defaults to `3`.|`2`|
 |minuteHandLength|Defines the length of a minute hand, in %. Defaults to `70`.|`80`|
-|minuteHandOppositeLength|Defines the length of the part of a minute hand on the opposite side the hand is pointing to, in %. Defaults to `0`.|`20`|
+|minuteHandOppositeLength|Defines the length of the part of a minute hand on the opposite side the hand is pointing to, in %. Defaults to `10`.|`20`|
 |minuteHandWidth|Defines the width of a minute hand, in pixels. Defaults to `2`.|`3`|
 |minuteMarksLength|Defines the length of minute marks, in %. Defaults to `6`.|`8`|
 |minuteMarksWidth|Defines the width of a minute hand, in pixels. Defaults to `1`.|`2`|
@@ -84,7 +84,7 @@ Displays a complete clock.
 |renderMinuteMarks|Defines whether minute marks shall be rendered. Defaults to `true`.|`false`|
 |renderSecondHand|Defines whether second hand shall be rendered. Defaults to `true`.|`false`|
 |secondHandLength|Defines the length of a second hand, in %. Defaults to `90`.|`80`|
-|secondHandOppositeLength|Defines the length of the part of a second hand on the opposite side the hand is pointing to, in %. Defaults to `0`.|`20`|
+|secondHandOppositeLength|Defines the length of the part of a second hand on the opposite side the hand is pointing to, in %. Defaults to `10`.|`20`|
 |secondHandWidth|Defines the width of a second hand, in pixels. Defaults to `1`.|`2`|
 |size|Defines the size of the clock, in pixels. Defaults to `150`.|`250`|
 |value|Defines the value of the clock. Must be provided.|Date: `new Date()`|


### PR DESCRIPTION
Noticed that the defaults in the docs weren't right, thought I would update them! Thanks for the awesome package!